### PR TITLE
Removed packages & Organised apt-get installation

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -50,9 +50,7 @@ so simply copy and paste this in a terminal window:
 ### More copy and paste:
 [Hint: Running this command installs the other required packages to build android]
 
-     $ sudo apt-get update && sudo apt-get install git-core gnupg flex bison gperf libsdl1.2-dev libesd0-dev libwxgtk2.8-dev squashfs-tools 
-build-essential zip curl libncurses5-dev zlib1g-dev openjdk-7-jre openjdk-7-jdk pngcrush schedtool libxml2 libxml2-utils xsltproc lzop 
-libc6-dev schedtool g++-multilib lib32z1-dev lib32ncurses5-dev lib32readline-gplv2-dev gcc-multilib maven tmux screen w3m ncftp
+     $ sudo apt-get update && sudo apt-get install git-core gnupg flex bison gperf libsdl1.2-dev libesd0-dev squashfs-tools build-essential zip curl libncurses5-dev zlib1g-dev openjdk-7-jre openjdk-7-jdk pngcrush schedtool libxml2 libxml2-utils xsltproc lzop libc6-dev schedtool g++-multilib lib32z1-dev lib32ncurses5-dev gcc-multilib maven tmux screen w3m ncftp
 
 ### Getting the Source
 - Making required directories


### PR DESCRIPTION
These packages are useless and unecessary. Also is not possible to use them anyway.
Tried to build without them. No problems.

E: Unable to locate package libwxgtk2.8-dev
E: Unable to locate package  lib32readline-gplv2-dev

Also i organised a bit the necessary tools to build android.
