### PR TITLE
Fix the name of AOSiP.

### DIFF
--- a/snippets/rr.xml
+++ b/snippets/rr.xml
@@ -23,7 +23,7 @@
 <project path="packages/apps/LineageParts" name="android_packages_apps_LineageParts" remote="rr" />
 <project path="frameworks/base" name="android_frameworks_base" remote="rr" />
 <project path="prebuilts/clang/host/darwin-x86" name="clang-host-darwin-x86" remote="rr" clone-depth="1"/>
-<project path="prebuilts/clang/host/linux-x86" name="AOSIP/platform_prebuilts_clang_host_linux-x86" remote="github" revision="pie" clone-depth="1" />
+<project path="prebuilts/clang/host/linux-x86" name="AOSiP/platform_prebuilts_clang_host_linux-x86" remote="github" revision="pie" clone-depth="1" />
 <project path="vendor/rr" name="android_vendor_resurrection" remote="rr"/>
 <project path="packages/apps/Settings" name="Resurrection_packages_apps_Settings" remote="rr" />
 <project path="lineage-sdk" name="android_lineage-sdk" remote="rr" />


### PR DESCRIPTION
This fixes the issue where clang_host_linux-x86 coudlnt be downloaded because of the incorrect repo name.